### PR TITLE
Postprocessor-controlled concentration and temperature inflow BCs

### DIFF
--- a/include/bcs/PostprocessorInflowBC.h
+++ b/include/bcs/PostprocessorInflowBC.h
@@ -1,0 +1,23 @@
+#ifndef POSTPROCESSORINFLOWBC_H
+#define POSTPROCESSORINFLOWBC_H
+
+#include "IntegratedBC.h"
+
+class PostprocessorInflowBC;
+
+template <>
+InputParameters validParams<PostprocessorInflowBC>();
+
+class PostprocessorInflowBC : public IntegratedBC
+{
+public:
+  PostprocessorInflowBC(const InputParameters & parameters);
+
+protected:
+  RealVectorValue _velocity;
+  const PostprocessorValue & _postprocessor_value;
+  virtual Real computeQpResidual();
+  virtual Real computeQpJacobian();
+};
+
+#endif // POSTPROCESSORINFLOWBC_H

--- a/include/bcs/PostprocessorTempInflowBC.h
+++ b/include/bcs/PostprocessorTempInflowBC.h
@@ -1,0 +1,30 @@
+#ifndef POSTPROCESSORTEMPINFLOWBC_H
+#define POSTPROCESSORTEMPINFLOWBC_H
+
+#include "PostprocessorInflowBC.h"
+#include "JvarMapInterface.h"
+#include "DerivativeMaterialInterface.h"
+
+class PostprocessorTempInflowBC;
+
+template <>
+InputParameters validParams<PostprocessorTempInflowBC>();
+
+class PostprocessorTempInflowBC
+    : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<PostprocessorInflowBC>>
+{
+public:
+  PostprocessorTempInflowBC(const InputParameters & parameters);
+
+protected:
+  virtual void initialSetup() override;
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
+  const MaterialProperty<Real> & _rho;
+  const MaterialProperty<Real> & _d_rho_d_u;
+  const MaterialProperty<Real> & _cp;
+  const MaterialProperty<Real> & _d_cp_d_u;
+};
+
+#endif // POSTPROCESSORTEMPINFLOWBC_H

--- a/src/base/SquirrelApp.C
+++ b/src/base/SquirrelApp.C
@@ -25,6 +25,8 @@
 #include "RobinBC.h"
 #include "ExampleShapeSideIntegratedBC.h"
 #include "MatINSTemperatureNoBCBC.h"
+#include "PostprocessorInflowBC.h"
+#include "PostprocessorTempInflowBC.h"
 
 // user objects
 #include "NumShapeSideUserObject.h"
@@ -90,6 +92,8 @@ SquirrelApp::registerObjects(Factory & factory)
   registerBoundaryCondition(TemperatureOutflowBC);
   registerBoundaryCondition(InflowBC);
   registerBoundaryCondition(TemperatureInflowBC);
+  registerBoundaryCondition(PostprocessorInflowBC);
+  registerBoundaryCondition(PostprocessorTempInflowBC);
   registerKernel(MatINSTemperatureNoBCBC);
   registerUserObject(NumShapeSideUserObject);
   registerUserObject(DenomShapeSideUserObject);

--- a/src/bcs/PostprocessorInflowBC.C
+++ b/src/bcs/PostprocessorInflowBC.C
@@ -1,0 +1,32 @@
+#include "PostprocessorInflowBC.h"
+
+template <>
+InputParameters
+validParams<PostprocessorInflowBC>()
+{
+  InputParameters params = validParams<IntegratedBC>();
+  params.addRequiredParam<RealVectorValue>("velocity", "The velocity vector");
+  params.addRequiredParam<PostprocessorName>("postprocessor",
+                                             "The postprocessor determining inlet concentration");
+  return params;
+}
+
+PostprocessorInflowBC::PostprocessorInflowBC(const InputParameters & parameters)
+  : IntegratedBC(parameters),
+
+    _velocity(getParam<RealVectorValue>("velocity")),
+    _postprocessor_value(getPostprocessorValue("postprocessor"))
+{
+}
+
+Real
+PostprocessorInflowBC::computeQpResidual()
+{
+  return _test[_i][_qp] * _postprocessor_value * _velocity * _normals[_qp];
+}
+
+Real
+PostprocessorInflowBC::computeQpJacobian()
+{
+  return 0.;
+}

--- a/src/bcs/PostprocessorTempInflowBC.C
+++ b/src/bcs/PostprocessorTempInflowBC.C
@@ -1,0 +1,39 @@
+#include "PostprocessorTempInflowBC.h"
+
+template <>
+InputParameters
+validParams<PostprocessorTempInflowBC>()
+{
+  InputParameters params = validParams<PostprocessorInflowBC>();
+  return params;
+}
+
+PostprocessorTempInflowBC::PostprocessorTempInflowBC(const InputParameters & parameters)
+  : DerivativeMaterialInterface<JvarMapIntegratedBCInterface<PostprocessorInflowBC>>(parameters),
+    _rho(getMaterialProperty<Real>("rho")),
+    _d_rho_d_u(getMaterialPropertyDerivative<Real>("rho", _var.name())),
+    _cp(getMaterialProperty<Real>("cp")),
+    _d_cp_d_u(getMaterialPropertyDerivative<Real>("cp", _var.name()))
+{
+}
+
+void
+PostprocessorTempInflowBC::initialSetup()
+{
+  validateNonlinearCoupling<Real>("rho");
+  validateNonlinearCoupling<Real>("cp");
+}
+
+Real
+PostprocessorTempInflowBC::computeQpResidual()
+{
+  return _rho[_qp] * _cp[_qp] * PostprocessorInflowBC::computeQpResidual();
+}
+
+Real
+PostprocessorTempInflowBC::computeQpJacobian()
+{
+  return _rho[_qp] * _cp[_qp] * PostprocessorInflowBC::computeQpJacobian() +
+         _d_rho_d_u[_qp] * _phi[_j][_qp] * _cp[_qp] * PostprocessorInflowBC::computeQpResidual() +
+         _rho[_qp] * _d_cp_d_u[_qp] * _phi[_j][_qp] * PostprocessorInflowBC::computeQpResidual();
+}


### PR DESCRIPTION
This PR adds discontinous Galerkin boundary conditions for squirrel. These are primarily used for the modeling of heat and delayed neutron precursor transport around the primary loop of MSRs in moltres. An example of their usage can be seen in moltres/problems/LOSCA.