### PR TITLE
Update run_tests for python 3

### DIFF
--- a/run_tests
+++ b/run_tests
@@ -1,24 +1,13 @@
 #!/usr/bin/env python
-import sys, os, inspect
+import sys, os
 
-# Set the current working directory to the directory where this script is located
-os.chdir(os.path.abspath(os.path.dirname(sys.argv[0])))
+MOOSE_DIR = os.path.abspath(os.environ.get('MOOSE_DIR', os.path.join(os.path.dirname(__file__), '..', 'moose')))
 
-#### Set the name of the application here and moose directory relative to the application
-app_name = 'squirrel'
-
-MOOSE_DIR = os.path.abspath(os.path.join('..', 'moose'))
-#### See if a submodule is available
 if os.path.exists(os.path.abspath(os.path.join('moose', 'framework', 'Makefile'))):
   MOOSE_DIR = os.path.abspath('moose')
-#### See if MOOSE_DIR is already in the environment instead
-if os.environ.has_key("MOOSE_DIR"):
-  MOOSE_DIR = os.environ['MOOSE_DIR']
+MOOSE_DIR = os.environ.get('MOOSE_DIR', MOOSE_DIR)
 
 sys.path.append(os.path.join(MOOSE_DIR, 'python'))
-import path_tool
-path_tool.activate_module('TestHarness')
 
 from TestHarness import TestHarness
-# Run the tests!
-TestHarness.buildAndRun(sys.argv, app_name, MOOSE_DIR)
+TestHarness.buildAndRun(sys.argv, 'squirrel', MOOSE_DIR)


### PR DESCRIPTION
As a consequence of the MOOSE Framework update to Python 3, `run_tests` needs to be updated. 