### PR TITLE
Squirrel code clean-up -- validParams, pragmas, overrides

### DIFF
--- a/include/auxkernels/Density.h
+++ b/include/auxkernels/Density.h
@@ -3,15 +3,12 @@
 
 #include "AuxKernel.h"
 
-class Density;
-
-template <>
-InputParameters validParams<Density>();
-
 class Density : public AuxKernel
 {
 public:
   Density(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~Density() {}
 

--- a/include/auxkernels/Density.h
+++ b/include/auxkernels/Density.h
@@ -1,5 +1,4 @@
-#ifndef DENSITY_H
-#define DENSITY_H
+#pragma once
 
 #include "AuxKernel.h"
 
@@ -17,5 +16,3 @@ protected:
 
   const VariableValue & _density_log;
 };
-
-#endif // DENSITY_H

--- a/include/auxkernels/FunctionDerivativeAux.h
+++ b/include/auxkernels/FunctionDerivativeAux.h
@@ -4,11 +4,7 @@
 #include "AuxKernel.h"
 
 // Forward Declarations
-class FunctionDerivativeAux;
 class Function;
-
-template <>
-InputParameters validParams<FunctionDerivativeAux>();
 
 /**
  * Function auxiliary value
@@ -21,6 +17,8 @@ public:
    * constructor.
    */
   FunctionDerivativeAux(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeValue() override;

--- a/include/auxkernels/FunctionDerivativeAux.h
+++ b/include/auxkernels/FunctionDerivativeAux.h
@@ -1,5 +1,4 @@
-#ifndef FUNCTIONDERIVATIVEAUX_H
-#define FUNCTIONDERIVATIVEAUX_H
+#pragma once
 
 #include "AuxKernel.h"
 
@@ -27,5 +26,3 @@ protected:
   const Function & _func;
   unsigned int _component;
 };
-
-#endif // FUNCTIONDERIVATIVEAUX_H

--- a/include/base/SquirrelApp.h
+++ b/include/base/SquirrelApp.h
@@ -3,15 +3,13 @@
 
 #include "MooseApp.h"
 
-class SquirrelApp;
-
-template <>
-InputParameters validParams<SquirrelApp>();
-
 class SquirrelApp : public MooseApp
 {
 public:
   SquirrelApp(InputParameters parameters);
+
+  static InputParameters validParams();
+
   virtual ~SquirrelApp();
 
   static void registerApps();

--- a/include/base/SquirrelApp.h
+++ b/include/base/SquirrelApp.h
@@ -1,5 +1,4 @@
-#ifndef SQUIRRELAPP_H
-#define SQUIRRELAPP_H
+#pragma once
 
 #include "MooseApp.h"
 
@@ -15,5 +14,3 @@ public:
   static void registerApps();
   static void registerAll(Factory & f, ActionFactory & af, Syntax & s);
 };
-
-#endif /* SQUIRRELAPP_H */

--- a/include/bcs/ChannelGradientBC.h
+++ b/include/bcs/ChannelGradientBC.h
@@ -13,8 +13,8 @@ public:
 
 protected:
   virtual Real getGradient();
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   const MooseEnum _axis;
   const VectorPostprocessorValue & _channel_gradient_axis_coordinate;

--- a/include/bcs/ChannelGradientBC.h
+++ b/include/bcs/ChannelGradientBC.h
@@ -4,15 +4,12 @@
 
 #include "IntegratedBC.h"
 
-class ChannelGradientBC;
-
-template <>
-InputParameters validParams<ChannelGradientBC>();
-
 class ChannelGradientBC : public IntegratedBC
 {
 public:
   ChannelGradientBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real getGradient();

--- a/include/bcs/ChannelGradientBC.h
+++ b/include/bcs/ChannelGradientBC.h
@@ -1,6 +1,4 @@
-
-#ifndef CHANNELGRADIENTBC_H
-#define CHANNELGRADIENTBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -21,5 +19,3 @@ protected:
   const VectorPostprocessorValue & _channel_gradient_value;
   const MaterialProperty<Real> & _h;
 };
-
-#endif // CHANNELGRADIENTBC_H

--- a/include/bcs/DGDiffusionPostprocessorDirichletBC.h
+++ b/include/bcs/DGDiffusionPostprocessorDirichletBC.h
@@ -1,5 +1,4 @@
-#ifndef DGDIFFUSIONPOSTPROCESSORDIRICHLETBC_H
-#define DGDIFFUSIONPOSTPROCESSORDIRICHLETBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -22,5 +21,3 @@ protected:
   const Real & _sigma;
   const MaterialProperty<Real> & _diff;
 };
-
-#endif // DGDIFFUSIONPOSTPROCESSORDIRICHLETBC_H

--- a/include/bcs/DGDiffusionPostprocessorDirichletBC.h
+++ b/include/bcs/DGDiffusionPostprocessorDirichletBC.h
@@ -3,16 +3,12 @@
 
 #include "IntegratedBC.h"
 
-// Forward Declarations
-class DGDiffusionPostprocessorDirichletBC;
-
-template <>
-InputParameters validParams<DGDiffusionPostprocessorDirichletBC>();
-
 class DGDiffusionPostprocessorDirichletBC : public IntegratedBC
 {
 public:
   DGDiffusionPostprocessorDirichletBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;

--- a/include/bcs/DiffusiveFluxBC.h
+++ b/include/bcs/DiffusiveFluxBC.h
@@ -5,16 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-class DiffusiveFluxBC;
-
-template <>
-InputParameters validParams<DiffusiveFluxBC>();
-
 class DiffusiveFluxBC
     : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<IntegratedBC>>
 {
 public:
   DiffusiveFluxBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/bcs/DiffusiveFluxBC.h
+++ b/include/bcs/DiffusiveFluxBC.h
@@ -1,5 +1,4 @@
-#ifndef DIFFUSIVEFLUXBC_H
-#define DIFFUSIVEFLUXBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "JvarMapInterface.h"
@@ -21,5 +20,3 @@ protected:
   const MaterialProperty<Real> & _D;
   const MaterialProperty<Real> & _d_D_d_u;
 };
-
-#endif // DIFFUSIVEFLUXBC_H

--- a/include/bcs/ExampleShapeSideIntegratedBC.h
+++ b/include/bcs/ExampleShapeSideIntegratedBC.h
@@ -11,6 +11,8 @@ class ExampleShapeSideIntegratedBC : public NonlocalIntegratedBC
 public:
   ExampleShapeSideIntegratedBC(const InputParameters & parameters);
 
+  static InputParameters validParams();
+
 protected:
   virtual Real computeQpResidual();
   virtual Real computeQpJacobian();
@@ -32,8 +34,4 @@ protected:
   const std::vector<dof_id_type> & _v_dofs;
   Real _Vb;
 };
-
-template <>
-InputParameters validParams<ExampleShapeSideIntegratedBC>();
-
 #endif // EXAMPLESHAPESIDEINTEGRATEDBC_H

--- a/include/bcs/ExampleShapeSideIntegratedBC.h
+++ b/include/bcs/ExampleShapeSideIntegratedBC.h
@@ -14,13 +14,13 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned int jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned int jvar) override;
   /// new method for on-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index);
+  virtual Real computeQpNonlocalJacobian(dof_id_type dof_index) override;
   /// new method for off-diagonal jacobian contributions corresponding to non-local dofs
-  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index);
+  virtual Real computeQpNonlocalOffDiagJacobian(unsigned int jvar, dof_id_type dof_index) override;
 
   const NumShapeSideUserObject & _num_shp;
   const Real & _num_shp_integral;

--- a/include/bcs/ExampleShapeSideIntegratedBC.h
+++ b/include/bcs/ExampleShapeSideIntegratedBC.h
@@ -1,6 +1,4 @@
-
-#ifndef EXAMPLESHAPESIDEINTEGRATEDBC_H
-#define EXAMPLESHAPESIDEINTEGRATEDBC_H
+#pragma once
 
 #include "NonlocalIntegratedBC.h"
 #include "NumShapeSideUserObject.h"
@@ -34,4 +32,3 @@ protected:
   const std::vector<dof_id_type> & _v_dofs;
   Real _Vb;
 };
-#endif // EXAMPLESHAPESIDEINTEGRATEDBC_H

--- a/include/bcs/FlexiblePostprocessorDirichletBC.h
+++ b/include/bcs/FlexiblePostprocessorDirichletBC.h
@@ -3,11 +3,6 @@
 
 #include "NodalBC.h"
 
-class FlexiblePostprocessorDirichletBC;
-
-template <>
-InputParameters validParams<FlexiblePostprocessorDirichletBC>();
-
 /**
  * Boundary condition of a Dirichlet type
  *
@@ -18,6 +13,8 @@ class FlexiblePostprocessorDirichletBC : public NodalBC
 {
 public:
   FlexiblePostprocessorDirichletBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual() override;

--- a/include/bcs/FlexiblePostprocessorDirichletBC.h
+++ b/include/bcs/FlexiblePostprocessorDirichletBC.h
@@ -1,5 +1,4 @@
-#ifndef FLEXIBLEPOSTPROCESSORDIRICHLETBC_H
-#define FLEXIBLEPOSTPROCESSORDIRICHLETBC_H
+#pragma once
 
 #include "NodalBC.h"
 
@@ -24,5 +23,3 @@ protected:
   const Real & _scale;
   const Real & _offset;
 };
-
-#endif /* FLEXIBLEPOSTPROCESSORDIRICHLETBC_H */

--- a/include/bcs/InflowBC.h
+++ b/include/bcs/InflowBC.h
@@ -3,15 +3,12 @@
 
 #include "IntegratedBC.h"
 
-class InflowBC;
-
-template <>
-InputParameters validParams<InflowBC>();
-
 class InflowBC : public IntegratedBC
 {
 public:
   InflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   const Real & _uu;

--- a/include/bcs/InflowBC.h
+++ b/include/bcs/InflowBC.h
@@ -11,12 +11,13 @@ public:
   static InputParameters validParams();
 
 protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
   const Real & _uu;
   const Real & _vv;
   const Real & _ww;
   const Real & _inlet_conc;
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
 };
 
 #endif // INFLOWBC_H

--- a/include/bcs/InflowBC.h
+++ b/include/bcs/InflowBC.h
@@ -1,5 +1,4 @@
-#ifndef INFLOWBC_H
-#define INFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -19,5 +18,3 @@ protected:
   const Real & _ww;
   const Real & _inlet_conc;
 };
-
-#endif // INFLOWBC_H

--- a/include/bcs/MatINSTemperatureNoBCBC.h
+++ b/include/bcs/MatINSTemperatureNoBCBC.h
@@ -17,9 +17,9 @@ public:
   virtual ~MatINSTemperatureNoBCBC() {}
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
-  virtual Real computeQpOffDiagJacobian(unsigned jvar);
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+  virtual Real computeQpOffDiagJacobian(unsigned jvar) override;
 
   const MaterialProperty<Real> & _k;
 };

--- a/include/bcs/MatINSTemperatureNoBCBC.h
+++ b/include/bcs/MatINSTemperatureNoBCBC.h
@@ -1,5 +1,4 @@
-#ifndef MATINSTEMPERATURENOBCBC_H
-#define MATINSTEMPERATURENOBCBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -23,5 +22,3 @@ protected:
 
   const MaterialProperty<Real> & _k;
 };
-
-#endif // MATINSTEMPERATURENOBCBC_H

--- a/include/bcs/MatINSTemperatureNoBCBC.h
+++ b/include/bcs/MatINSTemperatureNoBCBC.h
@@ -3,12 +3,6 @@
 
 #include "IntegratedBC.h"
 
-// Forward Declarations
-class MatINSTemperatureNoBCBC;
-
-template <>
-InputParameters validParams<MatINSTemperatureNoBCBC>();
-
 /**
  * This class implements the "No BC" boundary condition
  * discussed by Griffiths, Papanastiou, and others.
@@ -17,6 +11,8 @@ class MatINSTemperatureNoBCBC : public IntegratedBC
 {
 public:
   MatINSTemperatureNoBCBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~MatINSTemperatureNoBCBC() {}
 

--- a/include/bcs/OutflowBC.h
+++ b/include/bcs/OutflowBC.h
@@ -11,8 +11,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   RealVectorValue _velocity;
 };

--- a/include/bcs/OutflowBC.h
+++ b/include/bcs/OutflowBC.h
@@ -1,5 +1,4 @@
-#ifndef OUTFLOWBC_H
-#define OUTFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -16,5 +15,3 @@ protected:
 
   RealVectorValue _velocity;
 };
-
-#endif // OUTFLOWBC_H

--- a/include/bcs/OutflowBC.h
+++ b/include/bcs/OutflowBC.h
@@ -3,15 +3,12 @@
 
 #include "IntegratedBC.h"
 
-class OutflowBC;
-
-template <>
-InputParameters validParams<OutflowBC>();
-
 class OutflowBC : public IntegratedBC
 {
 public:
   OutflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual();

--- a/include/bcs/PostprocessorInflowBC.h
+++ b/include/bcs/PostprocessorInflowBC.h
@@ -1,5 +1,4 @@
-#ifndef POSTPROCESSORINFLOWBC_H
-#define POSTPROCESSORINFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -21,5 +20,3 @@ protected:
   const Real & _scale;
   const Real & _offset;
 };
-
-#endif // POSTPROCESSORINFLOWBC_H

--- a/include/bcs/PostprocessorInflowBC.h
+++ b/include/bcs/PostprocessorInflowBC.h
@@ -3,15 +3,12 @@
 
 #include "IntegratedBC.h"
 
-class PostprocessorInflowBC;
-
-template <>
-InputParameters validParams<PostprocessorInflowBC>();
-
 class PostprocessorInflowBC : public IntegratedBC
 {
 public:
   PostprocessorInflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   const Real & _uu;

--- a/include/bcs/PostprocessorInflowBC.h
+++ b/include/bcs/PostprocessorInflowBC.h
@@ -11,14 +11,15 @@ public:
   static InputParameters validParams();
 
 protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
   const Real & _uu;
   const Real & _vv;
   const Real & _ww;
   const PostprocessorValue & _pp_value;
   const Real & _scale;
   const Real & _offset;
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
 };
 
 #endif // POSTPROCESSORINFLOWBC_H

--- a/include/bcs/PostprocessorTemperatureInflowBC.h
+++ b/include/bcs/PostprocessorTemperatureInflowBC.h
@@ -5,16 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-class PostprocessorTemperatureInflowBC;
-
-template <>
-InputParameters validParams<PostprocessorTemperatureInflowBC>();
-
 class PostprocessorTemperatureInflowBC
     : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<PostprocessorInflowBC>>
 {
 public:
   PostprocessorTemperatureInflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/bcs/PostprocessorTemperatureInflowBC.h
+++ b/include/bcs/PostprocessorTemperatureInflowBC.h
@@ -1,5 +1,4 @@
-#ifndef POSTPROCESSORTEMPERATUREINFLOWBC_H
-#define POSTPROCESSORTEMPERATUREINFLOWBC_H
+#pragma once
 
 #include "PostprocessorInflowBC.h"
 #include "JvarMapInterface.h"
@@ -23,5 +22,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // POSTPROCESSORTEMPERATUREINFLOWBC_H

--- a/include/bcs/RobinBC.h
+++ b/include/bcs/RobinBC.h
@@ -4,15 +4,12 @@
 
 #include "IntegratedBC.h"
 
-class RobinBC;
-
-template <>
-InputParameters validParams<RobinBC>();
-
 class RobinBC : public IntegratedBC
 {
 public:
   RobinBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual();

--- a/include/bcs/RobinBC.h
+++ b/include/bcs/RobinBC.h
@@ -12,8 +12,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   Real _velocity;
 };

--- a/include/bcs/RobinBC.h
+++ b/include/bcs/RobinBC.h
@@ -1,6 +1,4 @@
-
-#ifndef ROBINBC_H
-#define ROBINBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -17,5 +15,3 @@ protected:
 
   Real _velocity;
 };
-
-#endif // ROBINBC_H

--- a/include/bcs/TemperatureInflowBC.h
+++ b/include/bcs/TemperatureInflowBC.h
@@ -1,5 +1,4 @@
-#ifndef TEMPERATUREINFLOWBC_H
-#define TEMPERATUREINFLOWBC_H
+#pragma once
 
 #include "InflowBC.h"
 #include "JvarMapInterface.h"
@@ -23,5 +22,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // TEMPERATUREINFLOWBC_H

--- a/include/bcs/TemperatureInflowBC.h
+++ b/include/bcs/TemperatureInflowBC.h
@@ -5,16 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-class TemperatureInflowBC;
-
-template <>
-InputParameters validParams<TemperatureInflowBC>();
-
 class TemperatureInflowBC
     : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<InflowBC>>
 {
 public:
   TemperatureInflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/bcs/TemperatureOutflowBC.h
+++ b/include/bcs/TemperatureOutflowBC.h
@@ -5,16 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-class TemperatureOutflowBC;
-
-template <>
-InputParameters validParams<TemperatureOutflowBC>();
-
 class TemperatureOutflowBC
     : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<OutflowBC>>
 {
 public:
   TemperatureOutflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/bcs/TemperatureOutflowBC.h
+++ b/include/bcs/TemperatureOutflowBC.h
@@ -1,5 +1,4 @@
-#ifndef TEMPERATUREOUTFLOWBC_H
-#define TEMPERATUREOUTFLOWBC_H
+#pragma once
 
 #include "OutflowBC.h"
 #include "JvarMapInterface.h"
@@ -23,5 +22,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // TEMPERATUREOUTFLOWBC_H

--- a/include/bcs/VelocityFunctionOutflowBC.h
+++ b/include/bcs/VelocityFunctionOutflowBC.h
@@ -11,8 +11,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   const Function & _vel_x_func;
   const Function & _vel_y_func;

--- a/include/bcs/VelocityFunctionOutflowBC.h
+++ b/include/bcs/VelocityFunctionOutflowBC.h
@@ -3,15 +3,12 @@
 
 #include "IntegratedBC.h"
 
-class VelocityFunctionOutflowBC;
-
-template <>
-InputParameters validParams<VelocityFunctionOutflowBC>();
-
 class VelocityFunctionOutflowBC : public IntegratedBC
 {
 public:
   VelocityFunctionOutflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual();

--- a/include/bcs/VelocityFunctionOutflowBC.h
+++ b/include/bcs/VelocityFunctionOutflowBC.h
@@ -1,5 +1,4 @@
-#ifndef VELOCITYFUNCTIONOUTFLOWBC_H
-#define VELOCITYFUNCTIONOUTFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 
@@ -18,5 +17,3 @@ protected:
   const Function & _vel_y_func;
   const Function & _vel_z_func;
 };
-
-#endif // VELOCITYFUNCTIONOUTFLOWBC_H

--- a/include/bcs/VelocityFunctionTemperatureOutflowBC.h
+++ b/include/bcs/VelocityFunctionTemperatureOutflowBC.h
@@ -5,16 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-class VelocityFunctionTemperatureOutflowBC;
-
-template <>
-InputParameters validParams<VelocityFunctionTemperatureOutflowBC>();
-
 class VelocityFunctionTemperatureOutflowBC
     : public DerivativeMaterialInterface<JvarMapIntegratedBCInterface<IntegratedBC>>
 {
 public:
   VelocityFunctionTemperatureOutflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/bcs/VelocityFunctionTemperatureOutflowBC.h
+++ b/include/bcs/VelocityFunctionTemperatureOutflowBC.h
@@ -1,5 +1,4 @@
-#ifndef VELOCITYFUNCTIONTEMPERATUREOUTFLOWBC_H
-#define VELOCITYFUNCTIONTEMPERATUREOUTFLOWBC_H
+#pragma once
 
 #include "IntegratedBC.h"
 #include "JvarMapInterface.h"
@@ -27,5 +26,3 @@ protected:
   const Function & _vel_y_func;
   const Function & _vel_z_func;
 };
-
-#endif // VELOCITYFUNCTIONTEMPERATUREOUTFLOWBC_H

--- a/include/dgkernels/DGCoupledAdvection.h
+++ b/include/dgkernels/DGCoupledAdvection.h
@@ -3,15 +3,12 @@
 
 #include "DGKernel.h"
 
-class DGCoupledAdvection;
-
-template <>
-InputParameters validParams<DGCoupledAdvection>();
-
 class DGCoupledAdvection : public DGKernel
 {
 public:
   DGCoupledAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual(Moose::DGResidualType type) override;

--- a/include/dgkernels/DGCoupledAdvection.h
+++ b/include/dgkernels/DGCoupledAdvection.h
@@ -1,5 +1,4 @@
-#ifndef DGCOUPLEDADVECTION_H
-#define DGCOUPLEDADVECTION_H
+#pragma once
 
 #include "DGKernel.h"
 
@@ -27,5 +26,3 @@ private:
   unsigned int _y_vel_var_number;
   unsigned int _z_vel_var_number;
 };
-
-#endif // DGCOUPLEDADVECTION_H

--- a/include/dgkernels/DGFunctionConvection.h
+++ b/include/dgkernels/DGFunctionConvection.h
@@ -3,15 +3,12 @@
 
 #include "DGKernel.h"
 
-class DGFunctionConvection;
-
-template <>
-InputParameters validParams<DGFunctionConvection>();
-
 class DGFunctionConvection : public DGKernel
 {
 public:
   DGFunctionConvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual(Moose::DGResidualType type);

--- a/include/dgkernels/DGFunctionConvection.h
+++ b/include/dgkernels/DGFunctionConvection.h
@@ -11,8 +11,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual(Moose::DGResidualType type);
-  virtual Real computeQpJacobian(Moose::DGJacobianType type);
+  virtual Real computeQpResidual(Moose::DGResidualType type) override;
+  virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
 
   RealVectorValue _velocity;
 

--- a/include/dgkernels/DGFunctionConvection.h
+++ b/include/dgkernels/DGFunctionConvection.h
@@ -1,5 +1,4 @@
-#ifndef DGFUNCTIONCONVECTION_H
-#define DGFUNCTIONCONVECTION_H
+#pragma once
 
 #include "DGKernel.h"
 
@@ -20,5 +19,3 @@ protected:
   const Function & _vel_y_func;
   const Function & _vel_z_func;
 };
-
-#endif // DGFUNCTIONCONVECTION_H

--- a/include/dgkernels/DGFunctionTemperatureAdvection.h
+++ b/include/dgkernels/DGFunctionTemperatureAdvection.h
@@ -4,15 +4,12 @@
 #include "DGFunctionConvection.h"
 #include "DerivativeMaterialInterface.h"
 
-class DGFunctionTemperatureAdvection;
-
-template <>
-InputParameters validParams<DGFunctionTemperatureAdvection>();
-
 class DGFunctionTemperatureAdvection : public DerivativeMaterialInterface<DGFunctionConvection>
 {
 public:
   DGFunctionTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/dgkernels/DGFunctionTemperatureAdvection.h
+++ b/include/dgkernels/DGFunctionTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef DGFUNCTIONTEMPERATUREADVECTION_H
-#define DGFUNCTIONTEMPERATUREADVECTION_H
+#pragma once
 
 #include "DGFunctionConvection.h"
 #include "DerivativeMaterialInterface.h"
@@ -19,5 +18,3 @@ protected:
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _cp;
 };
-
-#endif // DGFUNCTIONTEMPERATUREADVECTION_H

--- a/include/dgkernels/DGTemperatureAdvection.h
+++ b/include/dgkernels/DGTemperatureAdvection.h
@@ -3,15 +3,12 @@
 
 #include "DGKernel.h"
 
-class DGTemperatureAdvection;
-
-template <>
-InputParameters validParams<DGTemperatureAdvection>();
-
 class DGTemperatureAdvection : public DGKernel
 {
 public:
   DGTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual(Moose::DGResidualType type);

--- a/include/dgkernels/DGTemperatureAdvection.h
+++ b/include/dgkernels/DGTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef DGTEMPERATUREADVECTION_H
-#define DGTEMPERATUREADVECTION_H
+#pragma once
 
 #include "DGKernel.h"
 
@@ -18,5 +17,3 @@ protected:
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _cp;
 };
-
-#endif // DGTEMPERATUREADVECTION_H

--- a/include/dgkernels/DGTemperatureAdvection.h
+++ b/include/dgkernels/DGTemperatureAdvection.h
@@ -11,8 +11,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual(Moose::DGResidualType type);
-  virtual Real computeQpJacobian(Moose::DGJacobianType type);
+  virtual Real computeQpResidual(Moose::DGResidualType type) override;
+  virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
 
   RealVectorValue _velocity;
   const MaterialProperty<Real> & _rho;

--- a/include/interface_kernels/InterTemperatureAdvection.h
+++ b/include/interface_kernels/InterTemperatureAdvection.h
@@ -3,15 +3,12 @@
 
 #include "InterfaceKernel.h"
 
-class InterTemperatureAdvection;
-
-template <>
-InputParameters validParams<InterTemperatureAdvection>();
-
 class InterTemperatureAdvection : public InterfaceKernel
 {
 public:
   InterTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   const Real & _uu;

--- a/include/interface_kernels/InterTemperatureAdvection.h
+++ b/include/interface_kernels/InterTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef INTERTEMPERATUREADVECTION_H
-#define INTERTEMPERATUREADVECTION_H
+#pragma once
 
 #include "InterfaceKernel.h"
 
@@ -20,5 +19,3 @@ protected:
   virtual Real computeQpResidual(Moose::DGResidualType type) override;
   virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
 };
-
-#endif // INTERTEMPERATUREADVECTION_H

--- a/include/interface_kernels/InterTemperatureAdvection.h
+++ b/include/interface_kernels/InterTemperatureAdvection.h
@@ -17,8 +17,8 @@ protected:
   const MaterialProperty<Real> & _rho;
   const MaterialProperty<Real> & _cp;
   const Real & _heat_source;
-  virtual Real computeQpResidual(Moose::DGResidualType type);
-  virtual Real computeQpJacobian(Moose::DGJacobianType type);
+  virtual Real computeQpResidual(Moose::DGResidualType type) override;
+  virtual Real computeQpJacobian(Moose::DGJacobianType type) override;
 };
 
 #endif // INTERTEMPERATUREADVECTION_H

--- a/include/kernels/ConservativeTemperatureAdvection.h
+++ b/include/kernels/ConservativeTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef CONSERVATIVETEMPERATUREADVECTION_H
-#define CONSERVATIVETEMPERATUREADVECTION_H
+#pragma once
 
 #include "ConservativeAdvection.h"
 #include "JvarMapInterface.h"
@@ -23,5 +22,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // CONSERVATIVETEMPERATUREADVECTION_H

--- a/include/kernels/ConservativeTemperatureAdvection.h
+++ b/include/kernels/ConservativeTemperatureAdvection.h
@@ -5,17 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-// Forward Declaration
-class ConservativeTemperatureAdvection;
-
-template <>
-InputParameters validParams<ConservativeTemperatureAdvection>();
-
 class ConservativeTemperatureAdvection
     : public DerivativeMaterialInterface<JvarMapKernelInterface<ConservativeAdvection>>
 {
 public:
   ConservativeTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/kernels/CtrlConservativeAdvection.h
+++ b/include/kernels/CtrlConservativeAdvection.h
@@ -11,8 +11,8 @@ public:
   static InputParameters validParams();
 
 protected:
-  virtual Real computeQpResidual();
-  virtual Real computeQpJacobian();
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
 
   // velocity components
   const Real & _uu;

--- a/include/kernels/CtrlConservativeAdvection.h
+++ b/include/kernels/CtrlConservativeAdvection.h
@@ -1,5 +1,4 @@
-#ifndef CTRLCONSERVATIVEADVECTION_H
-#define CTRLCONSERVATIVEADVECTION_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -19,5 +18,3 @@ protected:
   const Real & _vv;
   const Real & _ww;
 };
-
-#endif // CTRLCONSERVATIVEADVECTION_H

--- a/include/kernels/CtrlConservativeAdvection.h
+++ b/include/kernels/CtrlConservativeAdvection.h
@@ -3,16 +3,12 @@
 
 #include "Kernel.h"
 
-// Forward Declaration
-class CtrlConservativeAdvection;
-
-template <>
-InputParameters validParams<CtrlConservativeAdvection>();
-
 class CtrlConservativeAdvection : public Kernel
 {
 public:
   CtrlConservativeAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual();

--- a/include/kernels/CtrlConservativeTemperatureAdvection.h
+++ b/include/kernels/CtrlConservativeTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef CTRLCONSERVATIVETEMPERATUREADVECTION_H
-#define CTRLCONSERVATIVETEMPERATUREADVECTION_H
+#pragma once
 
 #include "CtrlConservativeAdvection.h"
 #include "JvarMapInterface.h"
@@ -23,5 +22,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // CONSERVATIVETEMPERATUREADVECTION_H

--- a/include/kernels/CtrlConservativeTemperatureAdvection.h
+++ b/include/kernels/CtrlConservativeTemperatureAdvection.h
@@ -5,17 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-// Forward Declaration
-class CtrlConservativeTemperatureAdvection;
-
-template <>
-InputParameters validParams<CtrlConservativeTemperatureAdvection>();
-
 class CtrlConservativeTemperatureAdvection
     : public DerivativeMaterialInterface<JvarMapKernelInterface<CtrlConservativeAdvection>>
 {
 public:
   CtrlConservativeTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/kernels/MatINSTemperatureTimeDerivative.h
+++ b/include/kernels/MatINSTemperatureTimeDerivative.h
@@ -1,5 +1,4 @@
-#ifndef MATINSTEMPERATURETIMEDERIVATIVE_H
-#define MATINSTEMPERATURETIMEDERIVATIVE_H
+#pragma once
 
 #include "TimeDerivative.h"
 #include "JvarMapInterface.h"
@@ -29,5 +28,3 @@ protected:
   const MaterialProperty<Real> & _cp;
   const MaterialProperty<Real> & _d_cp_d_u;
 };
-
-#endif // MATINSTEMPERATURETIMEDERIVATIVE_H

--- a/include/kernels/MatINSTemperatureTimeDerivative.h
+++ b/include/kernels/MatINSTemperatureTimeDerivative.h
@@ -5,12 +5,6 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-// Forward Declarations
-class MatINSTemperatureTimeDerivative;
-
-template <>
-InputParameters validParams<MatINSTemperatureTimeDerivative>();
-
 /**
  * This class computes the time derivative for the incompressible
  * Navier-Stokes momentum equation.
@@ -20,6 +14,8 @@ class MatINSTemperatureTimeDerivative
 {
 public:
   MatINSTemperatureTimeDerivative(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~MatINSTemperatureTimeDerivative() {}
 

--- a/include/kernels/NonConservativeAdvection.h
+++ b/include/kernels/NonConservativeAdvection.h
@@ -3,16 +3,12 @@
 
 #include "Kernel.h"
 
-// Forward Declaration
-class NonConservativeAdvection;
-
-template <>
-InputParameters validParams<NonConservativeAdvection>();
-
 class NonConservativeAdvection : public Kernel
 {
 public:
   NonConservativeAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual Real computeQpResidual();

--- a/include/kernels/NonConservativeAdvection.h
+++ b/include/kernels/NonConservativeAdvection.h
@@ -1,5 +1,4 @@
-#ifndef NONCONSERVATIVEADVECTION_H
-#define NONCONSERVATIVEADVECTION_H
+#pragma once
 
 #include "Kernel.h"
 
@@ -16,5 +15,3 @@ protected:
 
   RealVectorValue _velocity;
 };
-
-#endif // NONCONSERVATIVEADVECTION_H

--- a/include/kernels/PotentialAdvection.h
+++ b/include/kernels/PotentialAdvection.h
@@ -3,15 +3,13 @@
 
 #include "Kernel.h"
 
-class PotentialAdvection;
-
-template <>
-InputParameters validParams<PotentialAdvection>();
-
 class PotentialAdvection : public Kernel
 {
 public:
   PotentialAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
+
   virtual ~PotentialAdvection();
 
 protected:

--- a/include/kernels/PotentialAdvection.h
+++ b/include/kernels/PotentialAdvection.h
@@ -1,5 +1,4 @@
-#ifndef POTENTIALADVECTION_H_
-#define POTENTIALADVECTION_H_
+#pragma once
 
 #include "Kernel.h"
 
@@ -23,5 +22,3 @@ private:
   VariableGradient _default;
   const VariableGradient & _grad_potential;
 };
-
-#endif // POTENTIALADVECTION_H

--- a/include/kernels/VelocityFunctionTemperatureAdvection.h
+++ b/include/kernels/VelocityFunctionTemperatureAdvection.h
@@ -1,5 +1,4 @@
-#ifndef VELOCITYFUNCTIONTEMPERATUREADVECTION_H
-#define VELOCITYFUNCTIONTEMPERATUREADVECTION_H
+#pragma once
 
 #include "Kernel.h"
 #include "JvarMapInterface.h"
@@ -27,5 +26,3 @@ protected:
   const Function & _vel_y_func;
   const Function & _vel_z_func;
 };
-
-#endif // VELOCITYFUNCTIONTEMPERATUREADVECTION_H

--- a/include/kernels/VelocityFunctionTemperatureAdvection.h
+++ b/include/kernels/VelocityFunctionTemperatureAdvection.h
@@ -5,17 +5,13 @@
 #include "JvarMapInterface.h"
 #include "DerivativeMaterialInterface.h"
 
-// Forward Declaration
-class VelocityFunctionTemperatureAdvection;
-
-template <>
-InputParameters validParams<VelocityFunctionTemperatureAdvection>();
-
 class VelocityFunctionTemperatureAdvection
     : public DerivativeMaterialInterface<JvarMapKernelInterface<Kernel>>
 {
 public:
   VelocityFunctionTemperatureAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
 protected:
   virtual void initialSetup() override;

--- a/include/userobjects/DenomShapeSideUserObject.h
+++ b/include/userobjects/DenomShapeSideUserObject.h
@@ -1,6 +1,4 @@
-
-#ifndef DENOMSHAPESIDEUSEROBJECT_H
-#define DENOMSHAPESIDEUSEROBJECT_H
+#pragma once
 
 #include "ShapeSideUserObject.h"
 
@@ -40,5 +38,3 @@ protected:
   unsigned int _u_var;
   const VariableGradient & _grad_u;
 };
-
-#endif

--- a/include/userobjects/DenomShapeSideUserObject.h
+++ b/include/userobjects/DenomShapeSideUserObject.h
@@ -4,12 +4,6 @@
 
 #include "ShapeSideUserObject.h"
 
-// Forward Declarations
-class DenomShapeSideUserObject;
-
-template <>
-InputParameters validParams<DenomShapeSideUserObject>();
-
 /**
  * Test and proof of concept class for computing UserObject Jacobians using the
  * ShapeSideUserObject base class. This object computes the integral
@@ -22,6 +16,8 @@ class DenomShapeSideUserObject : public ShapeSideUserObject
 {
 public:
   DenomShapeSideUserObject(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~DenomShapeSideUserObject() {}
 

--- a/include/userobjects/DenomShapeSideUserObject.h
+++ b/include/userobjects/DenomShapeSideUserObject.h
@@ -21,11 +21,11 @@ public:
 
   virtual ~DenomShapeSideUserObject() {}
 
-  virtual void initialize();
-  virtual void execute();
-  virtual void executeJacobian(unsigned int jvar);
-  virtual void finalize();
-  virtual void threadJoin(const UserObject & y);
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual void executeJacobian(unsigned int jvar) override;
+  virtual void finalize() override;
+  virtual void threadJoin(const UserObject & y) override;
 
   ///@{ custom UserObject interface functions
   const Real & getIntegral() const { return _integral; }

--- a/include/userobjects/NumShapeSideUserObject.h
+++ b/include/userobjects/NumShapeSideUserObject.h
@@ -4,12 +4,6 @@
 
 #include "ShapeSideUserObject.h"
 
-// Forward Declarations
-class NumShapeSideUserObject;
-
-template <>
-InputParameters validParams<NumShapeSideUserObject>();
-
 /**
  * Test and proof of concept class for computing UserObject Jacobians using the
  * ShapeSideUserObject base class. This object computes the integral
@@ -22,6 +16,8 @@ class NumShapeSideUserObject : public ShapeSideUserObject
 {
 public:
   NumShapeSideUserObject(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   virtual ~NumShapeSideUserObject() {}
 

--- a/include/userobjects/NumShapeSideUserObject.h
+++ b/include/userobjects/NumShapeSideUserObject.h
@@ -21,11 +21,11 @@ public:
 
   virtual ~NumShapeSideUserObject() {}
 
-  virtual void initialize();
-  virtual void execute();
-  virtual void executeJacobian(unsigned int jvar);
-  virtual void finalize();
-  virtual void threadJoin(const UserObject & y);
+  virtual void initialize() override;
+  virtual void execute() override;
+  virtual void executeJacobian(unsigned int jvar) override;
+  virtual void finalize() override;
+  virtual void threadJoin(const UserObject & y) override;
 
   ///@{ custom UserObject interface functions
   const Real & getIntegral() const { return _integral; }

--- a/include/userobjects/NumShapeSideUserObject.h
+++ b/include/userobjects/NumShapeSideUserObject.h
@@ -1,6 +1,4 @@
-
-#ifndef NUMSHAPESIDEUSEROBJECT_H
-#define NUMSHAPESIDEUSEROBJECT_H
+#pragma once
 
 #include "ShapeSideUserObject.h"
 
@@ -40,5 +38,3 @@ protected:
   unsigned int _u_var;
   const VariableGradient & _grad_u;
 };
-
-#endif

--- a/include/vectorpostprocessors/ChannelGradient.h
+++ b/include/vectorpostprocessors/ChannelGradient.h
@@ -1,5 +1,4 @@
-#ifndef CHANNELGRADIENT_H
-#define CHANNELGRADIENT_H
+#pragma once
 
 #include "GeneralVectorPostprocessor.h"
 
@@ -43,5 +42,3 @@ protected:
   VectorPostprocessorValue * _axis_values;
   VectorPostprocessorValue * _gradient_values;
 };
-
-#endif

--- a/include/vectorpostprocessors/ChannelGradient.h
+++ b/include/vectorpostprocessors/ChannelGradient.h
@@ -3,12 +3,6 @@
 
 #include "GeneralVectorPostprocessor.h"
 
-// Forward Declarations
-class ChannelGradient;
-
-template <>
-InputParameters validParams<ChannelGradient>();
-
 /**
  *  ChannelGradient is a VectorPostprocessor that performs a least squares
  *  fit on data calculated in another VectorPostprocessor.
@@ -22,6 +16,8 @@ public:
     * @param parameters The input parameters
     */
   ChannelGradient(const InputParameters & parameters);
+
+  static InputParameters validParams();
 
   /**
    * Initialize, clears old results

--- a/src/auxkernels/Density.C
+++ b/src/auxkernels/Density.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", Density);
 
-template <>
 InputParameters
-validParams<Density>()
+Density::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
 
   params.addRequiredCoupledVar("density_log", "The variable representing the log of the density.");
   return params;

--- a/src/auxkernels/FunctionDerivativeAux.C
+++ b/src/auxkernels/FunctionDerivativeAux.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", FunctionDerivativeAux);
 
-template <>
 InputParameters
-validParams<FunctionDerivativeAux>()
+FunctionDerivativeAux::validParams()
 {
-  InputParameters params = validParams<AuxKernel>();
+  InputParameters params = AuxKernel::validParams();
   params.addRequiredParam<FunctionName>("function", "The function to use as the value");
   params.addRequiredParam<unsigned int>(
       "component",

--- a/src/base/SquirrelApp.C
+++ b/src/base/SquirrelApp.C
@@ -4,11 +4,10 @@
 #include "ModulesApp.h"
 #include "MooseSyntax.h"
 
-template <>
 InputParameters
-validParams<SquirrelApp>()
+SquirrelApp::validParams()
 {
-  InputParameters params = validParams<MooseApp>();
+  InputParameters params = MooseApp::validParams();
 
   params.set<bool>("use_legacy_uo_initialization") = false;
   params.set<bool>("use_legacy_uo_aux_computation") = false;

--- a/src/bcs/ChannelGradientBC.C
+++ b/src/bcs/ChannelGradientBC.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", ChannelGradientBC);
 
-template <>
 InputParameters
-validParams<ChannelGradientBC>()
+ChannelGradientBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<VectorPostprocessorName>(
       "channel_gradient_pps", "The vector postprocessor name that holds the channel gradient.");
   MooseEnum axis_options("x y z");

--- a/src/bcs/DGDiffusionPostprocessorDirichletBC.C
+++ b/src/bcs/DGDiffusionPostprocessorDirichletBC.C
@@ -13,11 +13,10 @@
 
 registerMooseObject("SquirrelApp", DGDiffusionPostprocessorDirichletBC);
 
-template <>
 InputParameters
-validParams<DGDiffusionPostprocessorDirichletBC>()
+DGDiffusionPostprocessorDirichletBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addParam<Real>("value", 0.0, "The value the variable should have on the boundary");
   params.addRequiredParam<PostprocessorName>("postprocessor",
                                              "The postprocessor providing the "

--- a/src/bcs/DiffusiveFluxBC.C
+++ b/src/bcs/DiffusiveFluxBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", DiffusiveFluxBC);
 
-template <>
 InputParameters
-validParams<DiffusiveFluxBC>()
+DiffusiveFluxBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addParam<MaterialPropertyName>(
       "D_name", "D", "The name of the diffusivity, conductivity, or viscosity.");
   return params;

--- a/src/bcs/ExampleShapeSideIntegratedBC.C
+++ b/src/bcs/ExampleShapeSideIntegratedBC.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", ExampleShapeSideIntegratedBC);
 
-template <>
 InputParameters
-validParams<ExampleShapeSideIntegratedBC>()
+ExampleShapeSideIntegratedBC::validParams()
 {
-  InputParameters params = validParams<NonlocalIntegratedBC>();
+  InputParameters params = NonlocalIntegratedBC::validParams();
   params.addRequiredParam<UserObjectName>(
       "num_user_object", "ShapeSideUserObject for computing integral component in numerator.");
   params.addRequiredParam<UserObjectName>(

--- a/src/bcs/FlexiblePostprocessorDirichletBC.C
+++ b/src/bcs/FlexiblePostprocessorDirichletBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", FlexiblePostprocessorDirichletBC);
 
-template <>
 InputParameters
-validParams<FlexiblePostprocessorDirichletBC>()
+FlexiblePostprocessorDirichletBC::validParams()
 {
-  InputParameters p = validParams<NodalBC>();
+  InputParameters p = NodalBC::validParams();
   p.addRequiredParam<PostprocessorName>("postprocessor",
                                         "The postprocessor to set the value to on the boundary.");
   p.addParam<Real>("scale", 1., "The amount to scale the postprocessor value by");

--- a/src/bcs/InflowBC.C
+++ b/src/bcs/InflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", InflowBC);
 
-template <>
 InputParameters
-validParams<InflowBC>()
+InflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addParam<Real>("uu", 0, "The x-component of the velocity");
   params.addParam<Real>("vv", 0, "The y-component of the velocity");
   params.addParam<Real>("ww", 0, "The z-component of the velocity");

--- a/src/bcs/MatINSTemperatureNoBCBC.C
+++ b/src/bcs/MatINSTemperatureNoBCBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", MatINSTemperatureNoBCBC);
 
-template <>
 InputParameters
-validParams<MatINSTemperatureNoBCBC>()
+MatINSTemperatureNoBCBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
 
   // Required parameters
   params.addParam<MaterialPropertyName>("k",

--- a/src/bcs/OutflowBC.C
+++ b/src/bcs/OutflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", OutflowBC);
 
-template <>
 InputParameters
-validParams<OutflowBC>()
+OutflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<RealVectorValue>("velocity", "Velocity vector");
   params.addClassDescription("DG upwinding for the convection");
   return params;

--- a/src/bcs/PostprocessorInflowBC.C
+++ b/src/bcs/PostprocessorInflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", PostprocessorInflowBC);
 
-template <>
 InputParameters
-validParams<PostprocessorInflowBC>()
+PostprocessorInflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addParam<Real>("uu", 0, "The x-component of the velocity");
   params.addParam<Real>("vv", 0, "The y-component of the velocity");
   params.addParam<Real>("ww", 0, "The z-component of the velocity");

--- a/src/bcs/PostprocessorTemperatureInflowBC.C
+++ b/src/bcs/PostprocessorTemperatureInflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", PostprocessorTemperatureInflowBC);
 
-template <>
 InputParameters
-validParams<PostprocessorTemperatureInflowBC>()
+PostprocessorTemperatureInflowBC::validParams()
 {
-  InputParameters params = validParams<PostprocessorInflowBC>();
+  InputParameters params = PostprocessorInflowBC::validParams();
   return params;
 }
 

--- a/src/bcs/RobinBC.C
+++ b/src/bcs/RobinBC.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", RobinBC);
 
-template <>
 InputParameters
-validParams<RobinBC>()
+RobinBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addParam<Real>("velocity", 1, "The 1D velocity.");
   return params;
 }

--- a/src/bcs/TemperatureInflowBC.C
+++ b/src/bcs/TemperatureInflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", TemperatureInflowBC);
 
-template <>
 InputParameters
-validParams<TemperatureInflowBC>()
+TemperatureInflowBC::validParams()
 {
-  InputParameters params = validParams<InflowBC>();
+  InputParameters params = InflowBC::validParams();
   return params;
 }
 

--- a/src/bcs/TemperatureOutflowBC.C
+++ b/src/bcs/TemperatureOutflowBC.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", TemperatureOutflowBC);
 
-template <>
 InputParameters
-validParams<TemperatureOutflowBC>()
+TemperatureOutflowBC::validParams()
 {
-  InputParameters params = validParams<OutflowBC>();
+  InputParameters params = OutflowBC::validParams();
   return params;
 }
 

--- a/src/bcs/VelocityFunctionOutflowBC.C
+++ b/src/bcs/VelocityFunctionOutflowBC.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", VelocityFunctionOutflowBC);
 
-template <>
 InputParameters
-validParams<VelocityFunctionOutflowBC>()
+VelocityFunctionOutflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
   params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
   params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");

--- a/src/bcs/VelocityFunctionTemperatureOutflowBC.C
+++ b/src/bcs/VelocityFunctionTemperatureOutflowBC.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", VelocityFunctionTemperatureOutflowBC);
 
-template <>
 InputParameters
-validParams<VelocityFunctionTemperatureOutflowBC>()
+VelocityFunctionTemperatureOutflowBC::validParams()
 {
-  InputParameters params = validParams<IntegratedBC>();
+  InputParameters params = IntegratedBC::validParams();
   params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
   params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
   params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");

--- a/src/dgkernels/DGCoupledAdvection.C
+++ b/src/dgkernels/DGCoupledAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", DGCoupledAdvection);
 
-template <>
 InputParameters
-validParams<DGCoupledAdvection>()
+DGCoupledAdvection::validParams()
 {
-  InputParameters params = validParams<DGKernel>();
+  InputParameters params = DGKernel::validParams();
   params.addRequiredCoupledVar("uvel", "x direction velocity");
   params.addCoupledVar("vvel", 0, "y direction velocity");
   params.addCoupledVar("wvel", 0, "z direction velocity");

--- a/src/dgkernels/DGFunctionConvection.C
+++ b/src/dgkernels/DGFunctionConvection.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", DGFunctionConvection);
 
-template <>
 InputParameters
-validParams<DGFunctionConvection>()
+DGFunctionConvection::validParams()
 {
-  InputParameters params = validParams<DGKernel>();
+  InputParameters params = DGKernel::validParams();
   params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
   params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
   params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");

--- a/src/dgkernels/DGFunctionTemperatureAdvection.C
+++ b/src/dgkernels/DGFunctionTemperatureAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", DGFunctionTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<DGFunctionTemperatureAdvection>()
+DGFunctionTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<DGFunctionConvection>();
+  InputParameters params = DGFunctionConvection::validParams();
   params.addClassDescription("DG upwinding for func temp convection");
   return params;
 }

--- a/src/dgkernels/DGTemperatureAdvection.C
+++ b/src/dgkernels/DGTemperatureAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", DGTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<DGTemperatureAdvection>()
+DGTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<DGKernel>();
+  InputParameters params = DGKernel::validParams();
   params.addRequiredParam<RealVectorValue>("velocity", "Velocity vector");
   params.addClassDescription("DG upwinding for the convection");
   return params;

--- a/src/interface_kernels/InterTemperatureAdvection.C
+++ b/src/interface_kernels/InterTemperatureAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", InterTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<InterTemperatureAdvection>()
+InterTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<InterfaceKernel>();
+  InputParameters params = InterfaceKernel::validParams();
   params.addClassDescription("DG upwinding for the convection");
   params.addParam<Real>("heat_source", "Should have units of power/length^2");
   params.addParam<Real>("u_val", 0, "x velocity cm/s");

--- a/src/kernels/ConservativeTemperatureAdvection.C
+++ b/src/kernels/ConservativeTemperatureAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", ConservativeTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<ConservativeTemperatureAdvection>()
+ConservativeTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<ConservativeAdvection>();
+  InputParameters params = ConservativeAdvection::validParams();
   return params;
 }
 

--- a/src/kernels/CtrlConservativeAdvection.C
+++ b/src/kernels/CtrlConservativeAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", CtrlConservativeAdvection);
 
-template <>
 InputParameters
-validParams<CtrlConservativeAdvection>()
+CtrlConservativeAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addRequiredParam<Real>("u_val", "x-direction velocity");
   params.addRequiredParam<Real>("v_val", "y-direction velocity");
   params.addRequiredParam<Real>("w_val", "z-direction velocity");

--- a/src/kernels/CtrlConservativeTemperatureAdvection.C
+++ b/src/kernels/CtrlConservativeTemperatureAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", CtrlConservativeTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<CtrlConservativeTemperatureAdvection>()
+CtrlConservativeTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<CtrlConservativeAdvection>();
+  InputParameters params = CtrlConservativeAdvection::validParams();
   return params;
 }
 

--- a/src/kernels/MatINSTemperatureTimeDerivative.C
+++ b/src/kernels/MatINSTemperatureTimeDerivative.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", MatINSTemperatureTimeDerivative);
 
-template <>
 InputParameters
-validParams<MatINSTemperatureTimeDerivative>()
+MatINSTemperatureTimeDerivative::validParams()
 {
-  InputParameters params = validParams<TimeDerivative>();
+  InputParameters params = TimeDerivative::validParams();
   return params;
 }
 

--- a/src/kernels/NonConservativeAdvection.C
+++ b/src/kernels/NonConservativeAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", NonConservativeAdvection);
 
-template <>
 InputParameters
-validParams<NonConservativeAdvection>()
+NonConservativeAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addRequiredParam<RealVectorValue>("velocity", "Velocity Vector");
   return params;
 }

--- a/src/kernels/PotentialAdvection.C
+++ b/src/kernels/PotentialAdvection.C
@@ -2,11 +2,10 @@
 
 registerMooseObject("SquirrelApp", PotentialAdvection);
 
-template <>
 InputParameters
-validParams<PotentialAdvection>()
+PotentialAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addCoupledVar("potential", "The potential responsible for charge advection");
   params.addParam<bool>("positive_charge", true, "Whether the potential is advecting positive "
                                                  "charges. Should be set to false if charges are "

--- a/src/kernels/VelocityFunctionTemperatureAdvection.C
+++ b/src/kernels/VelocityFunctionTemperatureAdvection.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", VelocityFunctionTemperatureAdvection);
 
-template <>
 InputParameters
-validParams<VelocityFunctionTemperatureAdvection>()
+VelocityFunctionTemperatureAdvection::validParams()
 {
-  InputParameters params = validParams<Kernel>();
+  InputParameters params = Kernel::validParams();
   params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
   params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
   params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");

--- a/src/userobjects/DenomShapeSideUserObject.C
+++ b/src/userobjects/DenomShapeSideUserObject.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("SquirrelApp", DenomShapeSideUserObject);
 
-template <>
 InputParameters
-validParams<DenomShapeSideUserObject>()
+DenomShapeSideUserObject::validParams()
 {
-  InputParameters params = validParams<ShapeSideUserObject>();
+  InputParameters params = ShapeSideUserObject::validParams();
   params.addRequiredCoupledVar("u", "Charged specie density.");
   return params;
 }

--- a/src/userobjects/NumShapeSideUserObject.C
+++ b/src/userobjects/NumShapeSideUserObject.C
@@ -4,11 +4,10 @@
 
 registerMooseObject("SquirrelApp", NumShapeSideUserObject);
 
-template <>
 InputParameters
-validParams<NumShapeSideUserObject>()
+NumShapeSideUserObject::validParams()
 {
-  InputParameters params = validParams<ShapeSideUserObject>();
+  InputParameters params = ShapeSideUserObject::validParams();
   params.addRequiredCoupledVar("u", "Charged species density.");
   return params;
 }

--- a/src/vectorpostprocessors/ChannelGradient.C
+++ b/src/vectorpostprocessors/ChannelGradient.C
@@ -3,11 +3,10 @@
 
 registerMooseObject("SquirrelApp", ChannelGradient);
 
-template <>
 InputParameters
-validParams<ChannelGradient>()
+ChannelGradient::validParams()
 {
-  InputParameters params = validParams<GeneralVectorPostprocessor>();
+  InputParameters params = GeneralVectorPostprocessor::validParams();
 
   params.addRequiredParam<VectorPostprocessorName>(
       "lv1", "The line value sampler that will be on the LHS of the difference operation");


### PR DESCRIPTION
I needed some objects converted to static validParams for shannon-lab/zapdos#80, which resulted in this clean-up. This PR contains:

- Static validParams for all classes (this change also refs arfc/moltres#137)
- Adds missing overrides on functions overridden from parent classes
- Switches header `#ifndef`s to `#pragma once` in all headers (refs arfc/moltres#136).

Tagging @lindsayad for a review