### PR TITLE
Add MooseDocs to Squirrel

### DIFF
--- a/doc/config.yml
+++ b/doc/config.yml
@@ -1,0 +1,21 @@
+Content:
+    - ${ROOT_DIR}/doc/content
+    - ${MOOSE_DIR}/framework/doc/content
+
+Renderer:
+    type: MooseDocs.base.MaterializeRenderer
+
+Extensions:
+    MooseDocs.extensions.navigation:
+        name: Squirrel
+    MooseDocs.extensions.appsyntax:
+        executable: ${ROOT_DIR}
+        remove: !include ${MOOSE_DIR}/framework/doc/remove.yml
+        unregister: !include ${MOOSE_DIR}/framework/doc/unregister.yml
+        includes:
+            - include
+    MooseDocs.extensions.common:
+        shortcuts:
+            framework: !include ${MOOSE_DIR}/framework/doc/globals.yml
+    MooseDocs.extensions.acronym:
+        acronyms: !include ${MOOSE_DIR}/framework/doc/acronyms.yml

--- a/doc/content/index.md
+++ b/doc/content/index.md
@@ -1,0 +1,3 @@
+!config navigation breadcrumbs=False scrollspy=False
+
+# SquirrelApp

--- a/doc/content/source/auxkernels/Density.md
+++ b/doc/content/source/auxkernels/Density.md
@@ -1,0 +1,23 @@
+# Density
+
+!alert construction title=Undocumented Class
+The Density has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/Density
+
+## Overview
+
+!! Replace these lines with information regarding the Density object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the Density object.
+
+!syntax parameters /AuxKernels/Density
+
+!syntax inputs /AuxKernels/Density
+
+!syntax children /AuxKernels/Density

--- a/doc/content/source/auxkernels/FunctionDerivativeAux.md
+++ b/doc/content/source/auxkernels/FunctionDerivativeAux.md
@@ -1,0 +1,23 @@
+# FunctionDerivativeAux
+
+!alert construction title=Undocumented Class
+The FunctionDerivativeAux has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /AuxKernels/FunctionDerivativeAux
+
+## Overview
+
+!! Replace these lines with information regarding the FunctionDerivativeAux object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the FunctionDerivativeAux object.
+
+!syntax parameters /AuxKernels/FunctionDerivativeAux
+
+!syntax inputs /AuxKernels/FunctionDerivativeAux
+
+!syntax children /AuxKernels/FunctionDerivativeAux

--- a/doc/content/source/bcs/ChannelGradientBC.md
+++ b/doc/content/source/bcs/ChannelGradientBC.md
@@ -1,0 +1,23 @@
+# ChannelGradientBC
+
+!alert construction title=Undocumented Class
+The ChannelGradientBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/ChannelGradientBC
+
+## Overview
+
+!! Replace these lines with information regarding the ChannelGradientBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ChannelGradientBC object.
+
+!syntax parameters /BCs/ChannelGradientBC
+
+!syntax inputs /BCs/ChannelGradientBC
+
+!syntax children /BCs/ChannelGradientBC

--- a/doc/content/source/bcs/DGDiffusionPostprocessorDirichletBC.md
+++ b/doc/content/source/bcs/DGDiffusionPostprocessorDirichletBC.md
@@ -1,0 +1,23 @@
+# DGDiffusionPostprocessorDirichletBC
+
+!alert construction title=Undocumented Class
+The DGDiffusionPostprocessorDirichletBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/DGDiffusionPostprocessorDirichletBC
+
+## Overview
+
+!! Replace these lines with information regarding the DGDiffusionPostprocessorDirichletBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DGDiffusionPostprocessorDirichletBC object.
+
+!syntax parameters /BCs/DGDiffusionPostprocessorDirichletBC
+
+!syntax inputs /BCs/DGDiffusionPostprocessorDirichletBC
+
+!syntax children /BCs/DGDiffusionPostprocessorDirichletBC

--- a/doc/content/source/bcs/DiffusiveFluxBC.md
+++ b/doc/content/source/bcs/DiffusiveFluxBC.md
@@ -1,0 +1,23 @@
+# DiffusiveFluxBC
+
+!alert construction title=Undocumented Class
+The DiffusiveFluxBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/DiffusiveFluxBC
+
+## Overview
+
+!! Replace these lines with information regarding the DiffusiveFluxBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DiffusiveFluxBC object.
+
+!syntax parameters /BCs/DiffusiveFluxBC
+
+!syntax inputs /BCs/DiffusiveFluxBC
+
+!syntax children /BCs/DiffusiveFluxBC

--- a/doc/content/source/bcs/ExampleShapeSideIntegratedBC.md
+++ b/doc/content/source/bcs/ExampleShapeSideIntegratedBC.md
@@ -1,0 +1,23 @@
+# ExampleShapeSideIntegratedBC
+
+!alert construction title=Undocumented Class
+The ExampleShapeSideIntegratedBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/ExampleShapeSideIntegratedBC
+
+## Overview
+
+!! Replace these lines with information regarding the ExampleShapeSideIntegratedBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ExampleShapeSideIntegratedBC object.
+
+!syntax parameters /BCs/ExampleShapeSideIntegratedBC
+
+!syntax inputs /BCs/ExampleShapeSideIntegratedBC
+
+!syntax children /BCs/ExampleShapeSideIntegratedBC

--- a/doc/content/source/bcs/FlexiblePostprocessorDirichletBC.md
+++ b/doc/content/source/bcs/FlexiblePostprocessorDirichletBC.md
@@ -1,0 +1,23 @@
+# FlexiblePostprocessorDirichletBC
+
+!alert construction title=Undocumented Class
+The FlexiblePostprocessorDirichletBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/FlexiblePostprocessorDirichletBC
+
+## Overview
+
+!! Replace these lines with information regarding the FlexiblePostprocessorDirichletBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the FlexiblePostprocessorDirichletBC object.
+
+!syntax parameters /BCs/FlexiblePostprocessorDirichletBC
+
+!syntax inputs /BCs/FlexiblePostprocessorDirichletBC
+
+!syntax children /BCs/FlexiblePostprocessorDirichletBC

--- a/doc/content/source/bcs/InflowBC.md
+++ b/doc/content/source/bcs/InflowBC.md
@@ -1,0 +1,23 @@
+# InflowBC
+
+!alert construction title=Undocumented Class
+The InflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/InflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the InflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the InflowBC object.
+
+!syntax parameters /BCs/InflowBC
+
+!syntax inputs /BCs/InflowBC
+
+!syntax children /BCs/InflowBC

--- a/doc/content/source/bcs/MatINSTemperatureNoBCBC.md
+++ b/doc/content/source/bcs/MatINSTemperatureNoBCBC.md
@@ -1,0 +1,23 @@
+# MatINSTemperatureNoBCBC
+
+!alert construction title=Undocumented Class
+The MatINSTemperatureNoBCBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/MatINSTemperatureNoBCBC
+
+## Overview
+
+!! Replace these lines with information regarding the MatINSTemperatureNoBCBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MatINSTemperatureNoBCBC object.
+
+!syntax parameters /BCs/MatINSTemperatureNoBCBC
+
+!syntax inputs /BCs/MatINSTemperatureNoBCBC
+
+!syntax children /BCs/MatINSTemperatureNoBCBC

--- a/doc/content/source/bcs/OutflowBC.md
+++ b/doc/content/source/bcs/OutflowBC.md
@@ -1,0 +1,23 @@
+# OutflowBC
+
+!alert construction title=Undocumented Class
+The OutflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/OutflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the OutflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the OutflowBC object.
+
+!syntax parameters /BCs/OutflowBC
+
+!syntax inputs /BCs/OutflowBC
+
+!syntax children /BCs/OutflowBC

--- a/doc/content/source/bcs/PostprocessorInflowBC.md
+++ b/doc/content/source/bcs/PostprocessorInflowBC.md
@@ -1,0 +1,23 @@
+# PostprocessorInflowBC
+
+!alert construction title=Undocumented Class
+The PostprocessorInflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/PostprocessorInflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the PostprocessorInflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PostprocessorInflowBC object.
+
+!syntax parameters /BCs/PostprocessorInflowBC
+
+!syntax inputs /BCs/PostprocessorInflowBC
+
+!syntax children /BCs/PostprocessorInflowBC

--- a/doc/content/source/bcs/PostprocessorTemperatureInflowBC.md
+++ b/doc/content/source/bcs/PostprocessorTemperatureInflowBC.md
@@ -1,0 +1,23 @@
+# PostprocessorTemperatureInflowBC
+
+!alert construction title=Undocumented Class
+The PostprocessorTemperatureInflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/PostprocessorTemperatureInflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the PostprocessorTemperatureInflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PostprocessorTemperatureInflowBC object.
+
+!syntax parameters /BCs/PostprocessorTemperatureInflowBC
+
+!syntax inputs /BCs/PostprocessorTemperatureInflowBC
+
+!syntax children /BCs/PostprocessorTemperatureInflowBC

--- a/doc/content/source/bcs/RobinBC.md
+++ b/doc/content/source/bcs/RobinBC.md
@@ -1,0 +1,23 @@
+# RobinBC
+
+!alert construction title=Undocumented Class
+The RobinBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/RobinBC
+
+## Overview
+
+!! Replace these lines with information regarding the RobinBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the RobinBC object.
+
+!syntax parameters /BCs/RobinBC
+
+!syntax inputs /BCs/RobinBC
+
+!syntax children /BCs/RobinBC

--- a/doc/content/source/bcs/TemperatureInflowBC.md
+++ b/doc/content/source/bcs/TemperatureInflowBC.md
@@ -1,0 +1,23 @@
+# TemperatureInflowBC
+
+!alert construction title=Undocumented Class
+The TemperatureInflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/TemperatureInflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the TemperatureInflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the TemperatureInflowBC object.
+
+!syntax parameters /BCs/TemperatureInflowBC
+
+!syntax inputs /BCs/TemperatureInflowBC
+
+!syntax children /BCs/TemperatureInflowBC

--- a/doc/content/source/bcs/TemperatureOutflowBC.md
+++ b/doc/content/source/bcs/TemperatureOutflowBC.md
@@ -1,0 +1,23 @@
+# TemperatureOutflowBC
+
+!alert construction title=Undocumented Class
+The TemperatureOutflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/TemperatureOutflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the TemperatureOutflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the TemperatureOutflowBC object.
+
+!syntax parameters /BCs/TemperatureOutflowBC
+
+!syntax inputs /BCs/TemperatureOutflowBC
+
+!syntax children /BCs/TemperatureOutflowBC

--- a/doc/content/source/bcs/VelocityFunctionOutflowBC.md
+++ b/doc/content/source/bcs/VelocityFunctionOutflowBC.md
@@ -1,0 +1,23 @@
+# VelocityFunctionOutflowBC
+
+!alert construction title=Undocumented Class
+The VelocityFunctionOutflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/VelocityFunctionOutflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the VelocityFunctionOutflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VelocityFunctionOutflowBC object.
+
+!syntax parameters /BCs/VelocityFunctionOutflowBC
+
+!syntax inputs /BCs/VelocityFunctionOutflowBC
+
+!syntax children /BCs/VelocityFunctionOutflowBC

--- a/doc/content/source/bcs/VelocityFunctionTemperatureOutflowBC.md
+++ b/doc/content/source/bcs/VelocityFunctionTemperatureOutflowBC.md
@@ -1,0 +1,23 @@
+# VelocityFunctionTemperatureOutflowBC
+
+!alert construction title=Undocumented Class
+The VelocityFunctionTemperatureOutflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/VelocityFunctionTemperatureOutflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the VelocityFunctionTemperatureOutflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VelocityFunctionTemperatureOutflowBC object.
+
+!syntax parameters /BCs/VelocityFunctionTemperatureOutflowBC
+
+!syntax inputs /BCs/VelocityFunctionTemperatureOutflowBC
+
+!syntax children /BCs/VelocityFunctionTemperatureOutflowBC

--- a/doc/content/source/dgkernels/DGCoupledAdvection.md
+++ b/doc/content/source/dgkernels/DGCoupledAdvection.md
@@ -1,0 +1,23 @@
+# DGCoupledAdvection
+
+!alert construction title=Undocumented Class
+The DGCoupledAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /DGKernels/DGCoupledAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the DGCoupledAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DGCoupledAdvection object.
+
+!syntax parameters /DGKernels/DGCoupledAdvection
+
+!syntax inputs /DGKernels/DGCoupledAdvection
+
+!syntax children /DGKernels/DGCoupledAdvection

--- a/doc/content/source/dgkernels/DGFunctionConvection.md
+++ b/doc/content/source/dgkernels/DGFunctionConvection.md
@@ -1,0 +1,23 @@
+# DGFunctionConvection
+
+!alert construction title=Undocumented Class
+The DGFunctionConvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /DGKernels/DGFunctionConvection
+
+## Overview
+
+!! Replace these lines with information regarding the DGFunctionConvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DGFunctionConvection object.
+
+!syntax parameters /DGKernels/DGFunctionConvection
+
+!syntax inputs /DGKernels/DGFunctionConvection
+
+!syntax children /DGKernels/DGFunctionConvection

--- a/doc/content/source/dgkernels/DGFunctionTemperatureAdvection.md
+++ b/doc/content/source/dgkernels/DGFunctionTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# DGFunctionTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The DGFunctionTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /DGKernels/DGFunctionTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the DGFunctionTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DGFunctionTemperatureAdvection object.
+
+!syntax parameters /DGKernels/DGFunctionTemperatureAdvection
+
+!syntax inputs /DGKernels/DGFunctionTemperatureAdvection
+
+!syntax children /DGKernels/DGFunctionTemperatureAdvection

--- a/doc/content/source/dgkernels/DGTemperatureAdvection.md
+++ b/doc/content/source/dgkernels/DGTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# DGTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The DGTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /DGKernels/DGTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the DGTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DGTemperatureAdvection object.
+
+!syntax parameters /DGKernels/DGTemperatureAdvection
+
+!syntax inputs /DGKernels/DGTemperatureAdvection
+
+!syntax children /DGKernels/DGTemperatureAdvection

--- a/doc/content/source/interface_kernels/InterTemperatureAdvection.md
+++ b/doc/content/source/interface_kernels/InterTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# InterTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The InterTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /InterfaceKernels/InterTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the InterTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the InterTemperatureAdvection object.
+
+!syntax parameters /InterfaceKernels/InterTemperatureAdvection
+
+!syntax inputs /InterfaceKernels/InterTemperatureAdvection
+
+!syntax children /InterfaceKernels/InterTemperatureAdvection

--- a/doc/content/source/kernels/ConservativeTemperatureAdvection.md
+++ b/doc/content/source/kernels/ConservativeTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# ConservativeTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The ConservativeTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/ConservativeTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the ConservativeTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ConservativeTemperatureAdvection object.
+
+!syntax parameters /Kernels/ConservativeTemperatureAdvection
+
+!syntax inputs /Kernels/ConservativeTemperatureAdvection
+
+!syntax children /Kernels/ConservativeTemperatureAdvection

--- a/doc/content/source/kernels/CtrlConservativeAdvection.md
+++ b/doc/content/source/kernels/CtrlConservativeAdvection.md
@@ -1,0 +1,23 @@
+# CtrlConservativeAdvection
+
+!alert construction title=Undocumented Class
+The CtrlConservativeAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/CtrlConservativeAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the CtrlConservativeAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the CtrlConservativeAdvection object.
+
+!syntax parameters /Kernels/CtrlConservativeAdvection
+
+!syntax inputs /Kernels/CtrlConservativeAdvection
+
+!syntax children /Kernels/CtrlConservativeAdvection

--- a/doc/content/source/kernels/CtrlConservativeTemperatureAdvection.md
+++ b/doc/content/source/kernels/CtrlConservativeTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# CtrlConservativeTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The CtrlConservativeTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/CtrlConservativeTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the CtrlConservativeTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the CtrlConservativeTemperatureAdvection object.
+
+!syntax parameters /Kernels/CtrlConservativeTemperatureAdvection
+
+!syntax inputs /Kernels/CtrlConservativeTemperatureAdvection
+
+!syntax children /Kernels/CtrlConservativeTemperatureAdvection

--- a/doc/content/source/kernels/MatINSTemperatureTimeDerivative.md
+++ b/doc/content/source/kernels/MatINSTemperatureTimeDerivative.md
@@ -1,0 +1,23 @@
+# MatINSTemperatureTimeDerivative
+
+!alert construction title=Undocumented Class
+The MatINSTemperatureTimeDerivative has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/MatINSTemperatureTimeDerivative
+
+## Overview
+
+!! Replace these lines with information regarding the MatINSTemperatureTimeDerivative object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the MatINSTemperatureTimeDerivative object.
+
+!syntax parameters /Kernels/MatINSTemperatureTimeDerivative
+
+!syntax inputs /Kernels/MatINSTemperatureTimeDerivative
+
+!syntax children /Kernels/MatINSTemperatureTimeDerivative

--- a/doc/content/source/kernels/NonConservativeAdvection.md
+++ b/doc/content/source/kernels/NonConservativeAdvection.md
@@ -1,0 +1,23 @@
+# NonConservativeAdvection
+
+!alert construction title=Undocumented Class
+The NonConservativeAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/NonConservativeAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the NonConservativeAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the NonConservativeAdvection object.
+
+!syntax parameters /Kernels/NonConservativeAdvection
+
+!syntax inputs /Kernels/NonConservativeAdvection
+
+!syntax children /Kernels/NonConservativeAdvection

--- a/doc/content/source/kernels/PotentialAdvection.md
+++ b/doc/content/source/kernels/PotentialAdvection.md
@@ -1,0 +1,23 @@
+# PotentialAdvection
+
+!alert construction title=Undocumented Class
+The PotentialAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/PotentialAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the PotentialAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PotentialAdvection object.
+
+!syntax parameters /Kernels/PotentialAdvection
+
+!syntax inputs /Kernels/PotentialAdvection
+
+!syntax children /Kernels/PotentialAdvection

--- a/doc/content/source/kernels/VelocityFunctionTemperatureAdvection.md
+++ b/doc/content/source/kernels/VelocityFunctionTemperatureAdvection.md
@@ -1,0 +1,23 @@
+# VelocityFunctionTemperatureAdvection
+
+!alert construction title=Undocumented Class
+The VelocityFunctionTemperatureAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/VelocityFunctionTemperatureAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the VelocityFunctionTemperatureAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VelocityFunctionTemperatureAdvection object.
+
+!syntax parameters /Kernels/VelocityFunctionTemperatureAdvection
+
+!syntax inputs /Kernels/VelocityFunctionTemperatureAdvection
+
+!syntax children /Kernels/VelocityFunctionTemperatureAdvection

--- a/doc/content/source/userobjects/DenomShapeSideUserObject.md
+++ b/doc/content/source/userobjects/DenomShapeSideUserObject.md
@@ -1,0 +1,23 @@
+# DenomShapeSideUserObject
+
+!alert construction title=Undocumented Class
+The DenomShapeSideUserObject has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/DenomShapeSideUserObject
+
+## Overview
+
+!! Replace these lines with information regarding the DenomShapeSideUserObject object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the DenomShapeSideUserObject object.
+
+!syntax parameters /UserObjects/DenomShapeSideUserObject
+
+!syntax inputs /UserObjects/DenomShapeSideUserObject
+
+!syntax children /UserObjects/DenomShapeSideUserObject

--- a/doc/content/source/userobjects/NumShapeSideUserObject.md
+++ b/doc/content/source/userobjects/NumShapeSideUserObject.md
@@ -1,0 +1,23 @@
+# NumShapeSideUserObject
+
+!alert construction title=Undocumented Class
+The NumShapeSideUserObject has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /UserObjects/NumShapeSideUserObject
+
+## Overview
+
+!! Replace these lines with information regarding the NumShapeSideUserObject object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the NumShapeSideUserObject object.
+
+!syntax parameters /UserObjects/NumShapeSideUserObject
+
+!syntax inputs /UserObjects/NumShapeSideUserObject
+
+!syntax children /UserObjects/NumShapeSideUserObject

--- a/doc/content/source/vectorpostprocessors/ChannelGradient.md
+++ b/doc/content/source/vectorpostprocessors/ChannelGradient.md
@@ -1,0 +1,23 @@
+# ChannelGradient
+
+!alert construction title=Undocumented Class
+The ChannelGradient has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /VectorPostprocessors/ChannelGradient
+
+## Overview
+
+!! Replace these lines with information regarding the ChannelGradient object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the ChannelGradient object.
+
+!syntax parameters /VectorPostprocessors/ChannelGradient
+
+!syntax inputs /VectorPostprocessors/ChannelGradient
+
+!syntax children /VectorPostprocessors/ChannelGradient

--- a/doc/moosedocs.py
+++ b/doc/moosedocs.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+#* This file is part of the MOOSE framework
+#* https://www.mooseframework.org
+#*
+#* All rights reserved, see COPYRIGHT for full restrictions
+#* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+#*
+#* Licensed under LGPL 2.1, please see LICENSE for details
+#* https://www.gnu.org/licenses/lgpl-2.1.html
+
+import sys
+import os
+
+# Locate MOOSE directory
+MOOSE_DIR = os.getenv('MOOSE_DIR', os.path.abspath(os.path.join(os.path.dirname(__name__), '..', 'moose')))
+if not os.path.exists(MOOSE_DIR):
+    MOOSE_DIR = os.path.abspath(os.path.join(os.path.dirname(__name__), '..', '..', 'moose'))
+if not os.path.exists(MOOSE_DIR):
+    raise Exception('Failed to locate MOOSE, specify the MOOSE_DIR environment variable.')
+os.environ['MOOSE_DIR'] = MOOSE_DIR
+
+# Append MOOSE python directory
+MOOSE_PYTHON_DIR = os.path.join(MOOSE_DIR, 'python')
+if MOOSE_PYTHON_DIR not in sys.path:
+    sys.path.append(MOOSE_PYTHON_DIR)
+
+from MooseDocs import main
+if __name__ == '__main__':
+    sys.exit(main.run())


### PR DESCRIPTION
This PR adds basic MooseDocs capability to the Squirrel application, and also adds object documentation stub templates for all current Squirrel objects.

This addition is necessary so that Squirrel object documentation can be represented and linked on the Zapdos syntax documentation website. 

Tagging @smpark7 for review