### PR TITLE
Fixup deprecated ModulesApp method in SquirrelApp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,12 @@ include/base/*Revision.h
 # phase_field/tests/solution_rasterizer
 out.xyz
 build
+
+# Testing generated file
+.previous_test_results.json
+
+# Software info metadata file generated during make
+squirrel.yaml
+
+# VSCode dotfolder
+.vscode

--- a/src/base/SquirrelApp.C
+++ b/src/base/SquirrelApp.C
@@ -30,7 +30,7 @@ SquirrelApp::~SquirrelApp() {}
 void
 SquirrelApp::registerAll(Factory & f, ActionFactory & af, Syntax & s)
 {
-  ModulesApp::registerAll(f, af, s);
+  ModulesApp::registerAllObjects<SquirrelApp>(f, af, s);
   Registry::registerObjectsTo(f, {"SquirrelApp"});
   Registry::registerActionsTo(af, {"SquirrelApp"});
 


### PR DESCRIPTION
This fixes up a deprecated method that is affecting Zapdos. Tagging @smpark7 for review. Thanks! 