### PR TITLE
Add support for function-based velocity advection on constant and higher order discontinuous variables

### DIFF
--- a/doc/content/source/bcs/PostprocessorPenaltyDirichletBC.md
+++ b/doc/content/source/bcs/PostprocessorPenaltyDirichletBC.md
@@ -1,20 +1,13 @@
 # PostprocessorPenaltyDirichletBC
 
-!alert construction title=Undocumented Class
-The PostprocessorPenaltyDirichletBC has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /BCs/PostprocessorPenaltyDirichletBC
 
 ## Overview
 
-!! Replace these lines with information regarding the PostprocessorPenaltyDirichletBC object.
-
-## Example Input File Syntax
-
-!! Describe and include an example of how to use the PostprocessorPenaltyDirichletBC object.
+Enforces a Postprocessor Dirichlet boundary condition in a weak sense by penalizing differences
+between the current solution and the Dirichlet data. See
+[PenaltyDirichletBC](https://mooseframework.inl.gov/source/bcs/PenaltyDirichletBC.html) for more
+information on penalty BCs.
 
 !syntax parameters /BCs/PostprocessorPenaltyDirichletBC
 

--- a/doc/content/source/bcs/PostprocessorPenaltyDirichletBC.md
+++ b/doc/content/source/bcs/PostprocessorPenaltyDirichletBC.md
@@ -1,0 +1,23 @@
+# PostprocessorPenaltyDirichletBC
+
+!alert construction title=Undocumented Class
+The PostprocessorPenaltyDirichletBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/PostprocessorPenaltyDirichletBC
+
+## Overview
+
+!! Replace these lines with information regarding the PostprocessorPenaltyDirichletBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PostprocessorPenaltyDirichletBC object.
+
+!syntax parameters /BCs/PostprocessorPenaltyDirichletBC
+
+!syntax inputs /BCs/PostprocessorPenaltyDirichletBC
+
+!syntax children /BCs/PostprocessorPenaltyDirichletBC

--- a/doc/content/source/bcs/PostprocessorVelocityFunctionInflowBC.md
+++ b/doc/content/source/bcs/PostprocessorVelocityFunctionInflowBC.md
@@ -1,0 +1,23 @@
+# PostprocessorVelocityFunctionInflowBC
+
+!alert construction title=Undocumented Class
+The PostprocessorVelocityFunctionInflowBC has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /BCs/PostprocessorVelocityFunctionInflowBC
+
+## Overview
+
+!! Replace these lines with information regarding the PostprocessorVelocityFunctionInflowBC object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the PostprocessorVelocityFunctionInflowBC object.
+
+!syntax parameters /BCs/PostprocessorVelocityFunctionInflowBC
+
+!syntax inputs /BCs/PostprocessorVelocityFunctionInflowBC
+
+!syntax children /BCs/PostprocessorVelocityFunctionInflowBC

--- a/doc/content/source/bcs/PostprocessorVelocityFunctionInflowBC.md
+++ b/doc/content/source/bcs/PostprocessorVelocityFunctionInflowBC.md
@@ -1,20 +1,11 @@
 # PostprocessorVelocityFunctionInflowBC
 
-!alert construction title=Undocumented Class
-The PostprocessorVelocityFunctionInflowBC has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /BCs/PostprocessorVelocityFunctionInflowBC
 
 ## Overview
 
-!! Replace these lines with information regarding the PostprocessorVelocityFunctionInflowBC object.
-
-## Example Input File Syntax
-
-!! Describe and include an example of how to use the PostprocessorVelocityFunctionInflowBC object.
+Sets inflow boundary conditions for a problem with function-based velocity profile and inlet
+concentration postprocessor.
 
 !syntax parameters /BCs/PostprocessorVelocityFunctionInflowBC
 

--- a/doc/content/source/kernels/VelocityFunctionConservativeAdvection.md
+++ b/doc/content/source/kernels/VelocityFunctionConservativeAdvection.md
@@ -1,0 +1,23 @@
+# VelocityFunctionConservativeAdvection
+
+!alert construction title=Undocumented Class
+The VelocityFunctionConservativeAdvection has not been documented. The content listed below should be used as a starting point for
+documenting the class, which includes the typical automatic documentation associated with a
+MooseObject; however, what is contained is ultimately determined by what is necessary to make the
+documentation clear for users.
+
+!syntax description /Kernels/VelocityFunctionConservativeAdvection
+
+## Overview
+
+!! Replace these lines with information regarding the VelocityFunctionConservativeAdvection object.
+
+## Example Input File Syntax
+
+!! Describe and include an example of how to use the VelocityFunctionConservativeAdvection object.
+
+!syntax parameters /Kernels/VelocityFunctionConservativeAdvection
+
+!syntax inputs /Kernels/VelocityFunctionConservativeAdvection
+
+!syntax children /Kernels/VelocityFunctionConservativeAdvection

--- a/doc/content/source/kernels/VelocityFunctionConservativeAdvection.md
+++ b/doc/content/source/kernels/VelocityFunctionConservativeAdvection.md
@@ -1,20 +1,12 @@
 # VelocityFunctionConservativeAdvection
 
-!alert construction title=Undocumented Class
-The VelocityFunctionConservativeAdvection has not been documented. The content listed below should be used as a starting point for
-documenting the class, which includes the typical automatic documentation associated with a
-MooseObject; however, what is contained is ultimately determined by what is necessary to make the
-documentation clear for users.
-
 !syntax description /Kernels/VelocityFunctionConservativeAdvection
 
 ## Overview
 
-!! Replace these lines with information regarding the VelocityFunctionConservativeAdvection object.
-
-## Example Input File Syntax
-
-!! Describe and include an example of how to use the VelocityFunctionConservativeAdvection object.
+Implements a variant of
+[ConservativeAdvection](https://mooseframework.inl.gov/source/kernels/ConservativeAdvection.html)
+with the velocity set by a user-provided function.
 
 !syntax parameters /Kernels/VelocityFunctionConservativeAdvection
 

--- a/include/bcs/PostprocessorPenaltyDirichletBC.h
+++ b/include/bcs/PostprocessorPenaltyDirichletBC.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "IntegratedBC.h"
+
+/**
+ * Weakly enforce a Dirichlet BC using a penalty term similar to PenaltyDirichletBC, but with a
+ * postprocessor value instead of a scalar.
+ */
+class PostprocessorPenaltyDirichletBC : public IntegratedBC
+{
+public:
+  static InputParameters validParams();
+
+  PostprocessorPenaltyDirichletBC(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
+private:
+  Real _p;
+  const PostprocessorValue & _pp;
+};

--- a/include/bcs/PostprocessorPenaltyDirichletBC.h
+++ b/include/bcs/PostprocessorPenaltyDirichletBC.h
@@ -18,6 +18,6 @@ protected:
   virtual Real computeQpJacobian() override;
 
 private:
-  Real _p;
-  const PostprocessorValue & _pp;
+  Real _penalty;
+  const PostprocessorValue & _postprocessor;
 };

--- a/include/bcs/PostprocessorVelocityFunctionInflowBC.h
+++ b/include/bcs/PostprocessorVelocityFunctionInflowBC.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "IntegratedBC.h"
+
+/**
+ * Computes the inflow boundary condition contribution with inlet concentration set by a
+ * postprocessor, and the velocity set by functions.
+ */
+class PostprocessorVelocityFunctionInflowBC : public IntegratedBC
+{
+public:
+  PostprocessorVelocityFunctionInflowBC(const InputParameters & parameters);
+
+  static InputParameters validParams();
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
+  const Function & _vel_x_func;
+  const Function & _vel_y_func;
+  const Function & _vel_z_func;
+  const PostprocessorValue & _pp_value;
+  const Real & _scale;
+  const Real & _offset;
+};

--- a/include/kernels/VelocityFunctionConservativeAdvection.h
+++ b/include/kernels/VelocityFunctionConservativeAdvection.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "Kernel.h"
+
+/**
+ * Computes the conservative advection residual and jacobian contributions with velocity
+ * set by functions.
+ */
+class VelocityFunctionConservativeAdvection : public Kernel
+{
+public:
+  VelocityFunctionConservativeAdvection(const InputParameters & parameters);
+
+  static InputParameters validParams();
+
+protected:
+  virtual Real computeQpResidual() override;
+  virtual Real computeQpJacobian() override;
+
+  // velocity functions
+  const Function & _vel_x_func;
+  const Function & _vel_y_func;
+  const Function & _vel_z_func;
+};

--- a/src/bcs/PostprocessorPenaltyDirichletBC.C
+++ b/src/bcs/PostprocessorPenaltyDirichletBC.C
@@ -18,19 +18,19 @@ PostprocessorPenaltyDirichletBC::validParams()
 PostprocessorPenaltyDirichletBC::PostprocessorPenaltyDirichletBC(
     const InputParameters & parameters)
   : IntegratedBC(parameters),
-    _p(getParam<Real>("penalty")),
-    _pp(getPostprocessorValue("postprocessor"))
+    _penalty(getParam<Real>("penalty")),
+    _postprocessor(getPostprocessorValue("postprocessor"))
 {
 }
 
 Real
 PostprocessorPenaltyDirichletBC::computeQpResidual()
 {
-  return _p * _test[_i][_qp] * (-_pp + _u[_qp]);
+  return _penalty * _test[_i][_qp] * (-_postprocessor + _u[_qp]);
 }
 
 Real
 PostprocessorPenaltyDirichletBC::computeQpJacobian()
 {
-  return _p * _phi[_j][_qp] * _test[_i][_qp];
+  return _penalty * _phi[_j][_qp] * _test[_i][_qp];
 }

--- a/src/bcs/PostprocessorPenaltyDirichletBC.C
+++ b/src/bcs/PostprocessorPenaltyDirichletBC.C
@@ -1,0 +1,36 @@
+#include "PostprocessorPenaltyDirichletBC.h"
+
+registerMooseObject("SquirrelApp", PostprocessorPenaltyDirichletBC);
+
+InputParameters
+PostprocessorPenaltyDirichletBC::validParams()
+{
+  InputParameters params = IntegratedBC::validParams();
+  params.addRequiredParam<Real>("penalty", "Penalty scalar");
+  params.addRequiredParam<PostprocessorName>("postprocessor",
+      "Postprocessor to set the boundary value of the variable");
+  params.addClassDescription("Enforces a Dirichlet boundary condition "
+                             "in a weak sense by penalizing differences between the current "
+                             "solution and the Dirichlet postprocessor value.");
+  return params;
+}
+
+PostprocessorPenaltyDirichletBC::PostprocessorPenaltyDirichletBC(
+    const InputParameters & parameters)
+  : IntegratedBC(parameters),
+    _p(getParam<Real>("penalty")),
+    _pp(getPostprocessorValue("postprocessor"))
+{
+}
+
+Real
+PostprocessorPenaltyDirichletBC::computeQpResidual()
+{
+  return _p * _test[_i][_qp] * (-_pp + _u[_qp]);
+}
+
+Real
+PostprocessorPenaltyDirichletBC::computeQpJacobian()
+{
+  return _p * _phi[_j][_qp] * _test[_i][_qp];
+}

--- a/src/bcs/PostprocessorVelocityFunctionInflowBC.C
+++ b/src/bcs/PostprocessorVelocityFunctionInflowBC.C
@@ -1,0 +1,45 @@
+#include "PostprocessorVelocityFunctionInflowBC.h"
+
+registerMooseObject("SquirrelApp", PostprocessorVelocityFunctionInflowBC);
+
+InputParameters
+PostprocessorVelocityFunctionInflowBC::validParams()
+{
+  InputParameters params = IntegratedBC::validParams();
+  params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
+  params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
+  params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");
+  params.addRequiredParam<PostprocessorName>(
+      "postprocessor", "The postprocessor from which to derive the inlet concentration.");
+  params.addParam<Real>("scale", 1, "The amount to scale the postprocessor value by");
+  params.addParam<Real>("offset", 0, "The amount to offset the scaled postprocessor by");
+  return params;
+}
+
+PostprocessorVelocityFunctionInflowBC::PostprocessorVelocityFunctionInflowBC(
+    const InputParameters & parameters)
+  : IntegratedBC(parameters),
+    _vel_x_func(getFunction("vel_x_func")),
+    _vel_y_func(getFunction("vel_y_func")),
+    _vel_z_func(getFunction("vel_z_func")),
+    _pp_value(getPostprocessorValue("postprocessor")),
+    _scale(getParam<Real>("scale")),
+    _offset(getParam<Real>("offset"))
+{
+}
+
+Real
+PostprocessorVelocityFunctionInflowBC::computeQpResidual()
+{
+  RealVectorValue velocity = {_vel_x_func.value(_t, _q_point[_qp]),
+                              _vel_y_func.value(_t, _q_point[_qp]),
+                              _vel_z_func.value(_t, _q_point[_qp])};
+  Real inlet_conc = _scale * _pp_value + _offset;
+  return _test[_i][_qp] * inlet_conc * velocity * _normals[_qp];
+}
+
+Real
+PostprocessorVelocityFunctionInflowBC::computeQpJacobian()
+{
+  return 0.;
+}

--- a/src/kernels/VelocityFunctionConservativeAdvection.C
+++ b/src/kernels/VelocityFunctionConservativeAdvection.C
@@ -1,0 +1,41 @@
+#include "VelocityFunctionConservativeAdvection.h"
+#include "Function.h"
+
+registerMooseObject("SquirrelApp", VelocityFunctionConservativeAdvection);
+
+InputParameters
+VelocityFunctionConservativeAdvection::validParams()
+{
+  InputParameters params = Kernel::validParams();
+  params.addRequiredParam<FunctionName>("vel_x_func", "The x velocity function");
+  params.addRequiredParam<FunctionName>("vel_y_func", "The y velocity function");
+  params.addRequiredParam<FunctionName>("vel_z_func", "The z velocity function");
+  return params;
+}
+
+VelocityFunctionConservativeAdvection::VelocityFunctionConservativeAdvection(
+    const InputParameters & parameters)
+  : Kernel(parameters),
+    _vel_x_func(getFunction("vel_x_func")),
+    _vel_y_func(getFunction("vel_y_func")),
+    _vel_z_func(getFunction("vel_z_func"))
+{
+}
+
+Real
+VelocityFunctionConservativeAdvection::computeQpResidual()
+{
+  RealVectorValue v = {_vel_x_func.value(_t, _q_point[_qp]),
+                       _vel_y_func.value(_t, _q_point[_qp]),
+                       _vel_z_func.value(_t, _q_point[_qp])};
+  return -_grad_test[_i][_qp] * v * _u[_qp];
+}
+
+Real
+VelocityFunctionConservativeAdvection::computeQpJacobian()
+{
+  RealVectorValue v = {_vel_x_func.value(_t, _q_point[_qp]),
+                       _vel_y_func.value(_t, _q_point[_qp]),
+                       _vel_z_func.value(_t, _q_point[_qp])};
+  return -_grad_test[_i][_qp] * v * _phi[_j][_qp];
+}


### PR DESCRIPTION
## Description
`PostprocessorVelocityFunctionInflowBC` and `VelocityFunctionConservativeAdvection` are similar to `PostprocessorInflowBC` and `ConservativeAdvection`, but with function-based velocity profiles.

`PostprocessorPenaltyDirichletBC` is similar to `PenaltyDirichletBC`, but with a postprocessor to set the boundary value.

`PostprocessorVelocityFunctionInflowBC` is required to fix arfc/moltres#183.

`VelocityFunctionConservativeAdvection` and `PostprocessorPenaltyDirichletBC` are required to fix arfc/moltres#265.

## Changes
- Add `PostprocessorVelocityFunctionInflowBC`
- Add `VelocityFunctionConservativeAdvection`
- Add `PostprocessorPenaltyDirichletBC`